### PR TITLE
Fix sage math gf warnings

### DIFF
--- a/circkit/const_manager.py
+++ b/circkit/const_manager.py
@@ -25,9 +25,9 @@ class ConstManager:
 
 
 def const_2_int(value):
-    if hasattr(value, "integer_representation"):
+    if hasattr(value, "to_integer"):
         # sage's GF(p**k)
-        return value.integer_representation()
+        return value.to_integer()
     # try whatever
     return int(value)
 
@@ -53,7 +53,7 @@ class ArithmeticConstManager(ConstManager):
         super().__init__(circuit)
 
         self.base_ring = circuit.base_ring
-        self.has_int_repr = hasattr(self.base_ring(0), "integer_representation")
+        self.has_int_repr = hasattr(self.base_ring(0), "to_integer")
 
     def create(self, value):
         if isinstance(value, self.circuit.Node):
@@ -61,7 +61,7 @@ class ArithmeticConstManager(ConstManager):
             return self.create(value.value)
         if isinstance(value, int) or type(value).__name__ == "Integer":
             if self.has_int_repr:
-                return self.base_ring.fetch_int(value)
+                return self.base_ring.from_integer(value)
             return self.base_ring(value)
         elif hasattr(value, "parent") and value.parent().order() == self.base_ring.order():
             return value

--- a/tests/test_arithmetic_field.py
+++ b/tests/test_arithmetic_field.py
@@ -1,6 +1,12 @@
-from circkit.arithmetic import ArithmeticCircuit
-from sage.all import GF
 import random
+import pytest
+
+sage_all = pytest.importorskip("sage.all")
+if sage_all:
+    GF = sage_all.GF
+
+from circkit.arithmetic import ArithmeticCircuit
+
 K = GF(2**8)
 
 

--- a/tests/test_arithmetic_field.py
+++ b/tests/test_arithmetic_field.py
@@ -29,11 +29,11 @@ def test_toycircuit():
     out = C.evaluate(inp)
 
     def stdresults(a, b):
-        a = K.fetch_int(a)
-        b = K.fetch_int(b)
+        a = K.from_integer(a)
+        b = K.from_integer(b)
 
-        c5 = K.fetch_int(5)
-        c3 = K.fetch_int(3)
+        c5 = K.from_integer(5)
+        c3 = K.from_integer(3)
 
         x0 = a + b
         x1 = x0 - c5
@@ -41,5 +41,5 @@ def test_toycircuit():
         x3 = x2 / c3
         x4 = x3 ** 4
         x5 = ~x4
-        return [x4.integer_representation(), x5.integer_representation()]
+        return [x4.to_integer(), x5.to_integer()]
     assert out == stdresults(*inp)

--- a/tests/test_builtin_circuit.py
+++ b/tests/test_builtin_circuit.py
@@ -1,6 +1,12 @@
-from circkit.arithmetic import ArithmeticCircuit
-from sage.all import GF
 import random
+import pytest
+
+sage_all = pytest.importorskip("sage.all")
+if sage_all:
+    GF = sage_all.GF
+
+from circkit.arithmetic import ArithmeticCircuit
+
 K = GF(2**8)
 
 

--- a/tests/test_builtin_circuit.py
+++ b/tests/test_builtin_circuit.py
@@ -29,11 +29,11 @@ def test_toycircuit():
     out = C.evaluate(inp)
 
     def stdresults(a, b):
-        a = K.fetch_int(a)
-        b = K.fetch_int(b)
+        a = K.from_integer(a)
+        b = K.from_integer(b)
 
-        c5 = K.fetch_int(5)
-        c3 = K.fetch_int(3)
+        c5 = K.from_integer(5)
+        c3 = K.from_integer(3)
 
         x0 = a + b
         x1 = x0 - c5
@@ -41,5 +41,5 @@ def test_toycircuit():
         x3 = x2 / c3
         x4 = x3 ** 4
         x5 = ~x4
-        return [x4.integer_representation(), x5.integer_representation()]
+        return [x4.to_integer(), x5.to_integer()]
     assert out == stdresults(*inp)


### PR DESCRIPTION
Recent SageMath versions deprecate GF.fetch_int  and GF.integer_representation, need to use GF.from_integer and GF.to_integer.

Also, this PR skips testing GF when running outside Sage (e.g. pure python or pypy). Requires pytest (as in the cfg file)